### PR TITLE
added fetch top tracks

### DIFF
--- a/app/controllers/spotify_controller.rb
+++ b/app/controllers/spotify_controller.rb
@@ -44,30 +44,30 @@ class SpotifyController < ApplicationController
       render json: result
     end
 
-    # def fetch_top_tracks
-    #   # Used in Review and Comment only
-    #   token = session[:spotify_token]
-    #   url = "https://api.spotify.com/v1/me/top/tracks"
-    #   headers = { "Authorization" => "Bearer #{token}" }
+    def fetch_top_tracks
+      # Used in Review and Comment only
+      token = session[:spotify_token]
+      url = "https://api.spotify.com/v1/me/top/tracks"
+      headers = { "Authorization" => "Bearer #{token}" }
     
-    #   response = HTTParty.get(url, headers: headers)
+      response = HTTParty.get(url, headers: headers)
     
-    #   if response.success?
-    #     data = JSON.parse(response.body)
-    #     top_tracks = data["items"].map do |track|
-    #       {
-    #         name: track["name"],
-    #         artist: track["artists"].first["name"],
-    #         album: track["album"]["name"],
-    #         popularity: track["popularity"]
-    #       }
-    #     end
+      if response.success?
+        data = JSON.parse(response.body)
+        top_tracks = data["items"].map do |track|
+          {
+            name: track["name"],
+            artist: track["artists"].first["name"],
+            album: track["album"]["name"],
+            popularity: track["popularity"]
+          }
+        end
     
-    #     render json: top_tracks
-    #   else
-    #     render json: { error: "Unable to fetch top tracks" }, status: :bad_request
-    #   end
-    # end
+        render json: top_tracks
+      else
+        render json: { error: "Unable to fetch top tracks" }, status: :bad_request
+      end
+    end
     
   end
   


### PR DESCRIPTION
This pull request re-enables the `fetch_top_tracks` method in the `SpotifyController` by uncommenting the previously commented-out code. This method is used to fetch the user's top tracks from Spotify and return them as a JSON response.

Key change:

* [`app/controllers/spotify_controller.rb`](diffhunk://#diff-ee44c49ef2a6e761168d1e5d95b3b048c019358bc7e802e79f0ad5ea7e38ce37L47-R70): Uncommented and re-enabled the `fetch_top_tracks` method to allow fetching and rendering the user's top tracks from Spotify.